### PR TITLE
CustomFields + Segments

### DIFF
--- a/createsend/createsend.go
+++ b/createsend/createsend.go
@@ -13,7 +13,7 @@ import (
 const (
 	libraryVersion = "0.0.1"
 	userAgent      = "createsend-go/" + libraryVersion
-	defaultBaseURL = "https://api.createsend.com/api/v3/"
+	defaultBaseURL = "https://api.createsend.com/api/v3.1/"
 )
 
 // A APIClient manages communication with the Campaign Monitor API.
@@ -76,8 +76,9 @@ func (c *APIClient) NewRequest(method, urlStr string, body interface{}) (*http.R
 }
 
 type CreatesendError struct {
-	Code    int
-	Message string
+	Code       int
+	Message    string
+	ResultData interface{}
 }
 
 func (e *CreatesendError) Error() string {

--- a/createsend/lists.go
+++ b/createsend/lists.go
@@ -225,6 +225,10 @@ type ListSegment struct {
 	Title     string `json:"Title"`
 }
 
+// ListSegments list the segments for a given list.
+//
+// See https://www.campaignmonitor.com/api/lists/#list_segments for
+// more information.
 func (c *APIClient) ListSegments(listID string) ([]ListSegment, error) {
 	u := fmt.Sprintf("lists/%s/segments.json", listID)
 

--- a/createsend/lists.go
+++ b/createsend/lists.go
@@ -127,3 +127,117 @@ func (c *APIClient) ListCreate(clientID string, opt *ListCreateOptions) (string,
 
 	return s, nil
 }
+
+type DataType string
+
+const (
+	Text            DataType = "Text"
+	Number                   = "Number"
+	MultiSelectOne           = "MultiSelectOne"
+	MultiSelectMany          = "MultiSelectMany"
+	Date                     = "Date"
+	Country                  = "Country"
+	USState                  = "USState"
+)
+
+type CustomFieldDefinition struct {
+	FieldName                 string   `json:"FieldName"`
+	Key                       string   `json:"Key"`
+	DataType                  DataType `json:"DataType"`
+	FieldOptions              []string `json:"FieldOptions"`
+	VisibleInPreferenceCenter bool     `json:"VisibleInPreferenceCenter"`
+}
+
+// ListCustomFields returns a list of CustomFields for the given list.
+//
+// See https://www.campaignmonitor.com/api/lists/#list_custom_fields for
+// more information.
+func (c *APIClient) ListCustomFields(listID string) ([]CustomFieldDefinition, error) {
+	u := fmt.Sprintf("lists/%s/customfields.json", listID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []CustomFieldDefinition
+	err = c.Do(req, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+type CustomFieldCreate struct {
+	FieldName                 string   `json:"FieldName"`
+	DataType                  DataType `json:"DataType"`
+	Options                   []string `json:"Options,omitempty"`
+	VisibleInPreferenceCenter bool     `json:"VisibleInPreferenceCenter"`
+}
+
+// ListCreateCustomField creates a new CustomField on the given list.
+//
+// See https://www.campaignmonitor.com/api/lists/#creating_a_custom_field for
+// more information.
+func (c *APIClient) ListCreateCustomField(listID string, def *CustomFieldCreate) (string, error) {
+	u := fmt.Sprintf("lists/%s/customfields.json", listID)
+
+	req, err := c.NewRequest("POST", u, def)
+	if err != nil {
+		return "", err
+	}
+
+	var v interface{}
+	err = c.Do(req, &v)
+	if err != nil {
+		return "", err
+	}
+
+	r, ok := v.(string)
+	if !ok {
+		return "", errors.New("Return is not a string")
+	}
+
+	return r, nil
+}
+
+// ListDeleteCustomField deletes a CustomField from a given list.
+//
+// See https://www.campaignmonitor.com/api/lists/#deleting_a_custom_field for
+// more information.
+func (c *APIClient) ListDeleteCustomField(listID string, cfKey string) error {
+	u := fmt.Sprintf("lists/%s/customfields/%s.json", listID, cfKey)
+
+	req, err := c.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	err = c.Do(req, nil)
+
+	return err
+}
+
+type ListSegment struct {
+	ListID    string `json:"ListID"`
+	SegmentID string `json:"SegmentID"`
+	Title     string `json:"Title"`
+}
+
+func (c *APIClient) ListSegments(listID string) ([]ListSegment, error) {
+	u := fmt.Sprintf("lists/%s/segments.json", listID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []ListSegment
+	err = c.Do(req, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/createsend/lists_test.go
+++ b/createsend/lists_test.go
@@ -58,3 +58,145 @@ func TestListDelete(t *testing.T) {
 		t.Errorf("ListDelete returned error: %v", err)
 	}
 }
+
+func TestListCustomFields(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/lists/12CD/customfields.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[
+			{
+				"FieldName": "website",
+				"Key": "[website]",
+				"DataType": "Text",
+				"FieldOptions": [],
+				"VisibleInPreferenceCenter": true
+			},
+			{
+				"FieldName": "age",
+				"Key": "[age]",
+				"DataType": "Number",
+				"FieldOptions": [],
+				"VisibleInPreferenceCenter": true
+			},
+			{
+				"FieldName": "subscription date",
+				"Key": "[subscriptiondate]",
+				"DataType": "Date",
+				"FieldOptions": [],
+				"VisibleInPreferenceCenter": false
+			},
+			{
+				"FieldName": "newsletterformat",
+				"Key": "[newsletterformat]",
+				"DataType": "MultiSelectOne",
+				"FieldOptions": [
+					"HTML",
+					"Text"
+				],
+				"VisibleInPreferenceCenter": true
+			}
+		]`)
+	})
+
+	cfs, err := client.ListCustomFields("12CD")
+	if err != nil {
+		t.Errorf("ListCustomfields returned error: %v", err)
+	}
+
+	if len(cfs) != 4 {
+		t.Errorf("Expected 4 customfields but got %d", len(cfs))
+	}
+
+	if cfs[0].DataType != "Text" {
+		t.Errorf("Wrong datatype: %v", cfs[0].DataType)
+	}
+
+	if len(cfs[3].FieldOptions) != 2 {
+		t.Errorf("Expected 2 fieldoptions: %d", len(cfs[3].FieldOptions))
+	}
+
+}
+
+func TestListCreateCustomField(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/lists/12CD/customfields.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `"AE12"`)
+	})
+
+	id, err := client.ListCreateCustomField("12CD", &CustomFieldCreate{FieldName: "test", DataType: Text, VisibleInPreferenceCenter: false})
+	if err != nil {
+		t.Errorf("ListCreateCustomField return error: %v", err)
+	}
+
+	if id != "AE12" {
+		t.Errorf("Id returned is wrong: %v", id)
+	}
+}
+
+func TestListDeleteCustomField(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/lists/12CD/customfields/[test].json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.ListDeleteCustomField("12CD", "[test]")
+	if err != nil {
+		t.Errorf("ListDeleteCustomField return error: %v", err)
+	}
+}
+
+func TestListDeleteCustomFieldFail(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/lists/12CD/customfields/test.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"Code":253}`)
+	})
+
+	err := client.ListDeleteCustomField("12CD", "test")
+	if err == nil {
+		t.Errorf("ListDeleteCustomField did not return error")
+	}
+}
+
+func TestListSegments(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/lists/12CD/segments.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[
+				  {
+					"ListID": "12CD",
+					"SegmentID": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1",
+					"Title": "Segment One"
+				  },
+				  {
+					"ListID": "12CD",
+					"SegmentID": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+					"Title": "Segment Two"
+				  }
+				]`)
+	})
+
+	segments, err := client.ListSegments("12CD")
+	if err != nil {
+		t.Errorf("ListSegments returned an error: %v", err)
+	}
+
+	if len(segments) != 2 {
+		t.Errorf("Expected 2 ListsSegment's but got %d", len(segments))
+	}
+
+	if segments[0].ListID != "12CD" {
+		t.Errorf("Expected first listid to equal \"12CD\" but got \"%s\"", segments[0].ListID)
+	}
+}

--- a/createsend/segments.go
+++ b/createsend/segments.go
@@ -1,0 +1,68 @@
+package createsend
+
+import "fmt"
+
+type SegmentCreate struct {
+	Title      string            `json:"Title"`
+	RuleGroups []RuleGroupCreate `json:"RuleGroups"`
+}
+
+type RuleGroupCreate struct {
+	Rules []RuleCreate `json:"Rules"`
+}
+
+type RuleCreate struct {
+	RuleType string `json:"RuleType"`
+	Clause   string `json:"Clause"`
+}
+
+// Create a new segment on the given list.
+//
+// See https://www.campaignmonitor.com/api/segments/#creating_a_segment for more
+// information.
+func (c *APIClient) SegmentCreate(listID string, sgmt *SegmentCreate) (string, error) {
+	u := fmt.Sprintf("segments/%s.json", listID)
+
+	req, err := c.NewRequest("POST", u, sgmt)
+	if err != nil {
+		return "", err
+	}
+
+	var r string
+	err = c.Do(req, &r)
+	if err != nil {
+		return "", err
+	}
+
+	return r, nil
+}
+
+type SegmentDetail struct {
+	ActiveSubscribers int               `json:"ActiveSubscribers"`
+	RuleGroups        []RuleGroupCreate `json:"RuleGroups"`
+	ListID            string            `json:"ListID"`
+	SegmentID         string            `json:"SegmentID"`
+	Title             string            `json:"Title"`
+}
+
+// Fetch segment details for a given segment.
+//
+// See https://www.campaignmonitor.com/api/segments/#getting_a_segments_details for more
+// information.
+func (c *APIClient) SegmentDetail(segmentID string) (*SegmentDetail, error) {
+	u := fmt.Sprintf("segments/%s.json", segmentID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var s SegmentDetail
+	err = c.Do(req, &s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+
+}

--- a/createsend/segments_test.go
+++ b/createsend/segments_test.go
@@ -1,0 +1,105 @@
+package createsend
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestSegmentCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/12CD.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `"EQS1"`)
+	})
+
+	rg := make([]RuleGroupCreate, 1)
+	rg[0].Rules = []RuleCreate{RuleCreate{RuleType: "DateSubscribed", Clause: "AFTER 2009-01-01"}}
+
+	sgmt := SegmentCreate{Title: "Test", RuleGroups: rg}
+	id, err := client.SegmentCreate("12CD", &sgmt)
+
+	if err != nil {
+		t.Errorf("SegmentCreate returned error: %v", err)
+	}
+
+	if id != "EQS1" {
+		t.Errorf("Incorrect id returned: %v", id)
+	}
+
+}
+
+func TestSegmentCreateFail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/12CD.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"Code" : 275}`)
+	})
+
+	rg := make([]RuleGroupCreate, 1)
+	rg[0].Rules = []RuleCreate{RuleCreate{RuleType: "DateSubscribed", Clause: "AFTER 2009-01-01"}}
+
+	sgmt := SegmentCreate{Title: "Test", RuleGroups: rg}
+	_, err := client.SegmentCreate("12CD", &sgmt)
+
+	if err == nil {
+		t.Errorf("SegmentCreate returned no error")
+	}
+}
+
+func TestSegmentDetail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/12CD.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+				"ActiveSubscribers": 1,
+				"RuleGroups": [
+					{
+						"Rules": [
+							{
+								"RuleType": "Subject1_1",
+								"Clause": "Clause1_1"
+							},
+							{
+								"RuleType": "Subject1_2",
+								"Clause": "Clause1_2"
+							}
+						]
+					},
+					{
+						"Rules": [
+							{
+								"RuleType": "Subject2_1",
+								"Clause": "Clause2_1"
+							}
+						]
+					}
+				],
+				"ListID": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+				"SegmentID": "12CD",
+				"Title": "Segment Title"
+			}`)
+	})
+
+	s, err := client.SegmentDetail("12CD")
+	if err != nil {
+		t.Errorf("SegmentDetail returned an error")
+	}
+
+	if s.ActiveSubscribers != 1 {
+		t.Errorf("Expected 1 active subscriber but got: %d", s.ActiveSubscribers)
+	}
+
+	if s.SegmentID != "12CD" {
+		t.Errorf("Expected SegmentID 12CD but got: %s", s.SegmentID)
+	}
+}


### PR DESCRIPTION
Implemented ListCreateCustomField & ListDeleteCustomField
Added segments (basic implementation): SegmentCreate + SegmentDetails + ListSegments

Now runs op API v3.1, which is needed to be able to work with Segments. As far as I can tell from the CampaignMonitor documentation this was the only change from v3 -> v3.1