### PR TITLE
Add API Call for UpdateSubscriber

### DIFF
--- a/createsend/subscribers.go
+++ b/createsend/subscribers.go
@@ -41,6 +41,21 @@ func (c *APIClient) AddSubscriber(listID string, sub NewSubscriber) error {
 	return c.Do(req, nil)
 }
 
+// UpdateSubscriber updates a subscriber.
+//
+// See http://www.campaignmonitor.com/api/subscribers/#updating_a_subscriber for
+// more information.
+func (c *APIClient) UpdateSubscriber(listID string, email string, sub NewSubscriber) error {
+	u := fmt.Sprintf("subscribers/%s.json?email=%s", listID, email)
+
+	req, err := c.NewRequest("PUT", u, sub)
+	if err != nil {
+		return err
+	}
+
+	return c.Do(req, nil)
+}
+
 // Subscriber represents a subscriber.
 //
 // See

--- a/createsend/subscribers_test.go
+++ b/createsend/subscribers_test.go
@@ -27,6 +27,26 @@ func TestAddSubscriber(t *testing.T) {
 	}
 }
 
+func TestUpdateSubscriber(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/subscribers/12CD.json", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testQuerystring(t, r, "email=alice@example.com")
+		fmt.Fprint(w, "OK")
+	})
+
+	sub := NewSubscriber{
+		EmailAddress: "alice@example.net",
+		Name:         "Alice",
+	}
+	err := client.UpdateSubscriber("12CD", "alice@example.com", sub)
+	if err != nil {
+		t.Errorf("AddSubscriber returned error: %v", err)
+	}
+}
+
 func TestGetSubscriber(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
I've gone with using a NewSubscriber struct as the input for this, as the fields are identical.
Main change is the appending of the (original) email address in the query params, and changing the request to a PUT.

